### PR TITLE
msm8953-common: Add wowlan_triggers to wpa_supplicant conf

### DIFF
--- a/wifi/wpa_supplicant_overlay.conf
+++ b/wifi/wpa_supplicant_overlay.conf
@@ -1,3 +1,4 @@
 disable_scan_offload=1
 p2p_disabled=1
 tdls_external_control=1
+wowlan_triggers=magic_pkt


### PR DESCRIPTION
Add 'wowlan_triggers=magic_pkt' to wpa_supplicant_overlay.conf. With
this, wpa_supplicant will tell the linux kernel that the wifi driver
is wowlan capable, and will wakeup the host when a magic packet is
received. Most importantly, the kernel will no longer disconnect wifi
connections before suspending wifi.

Change-Id: I3226943940046ad98e4ab410897d4fdcb457ee5a
CRs-Fixed: 2076216